### PR TITLE
Fix missing g_ImageTexture dictionary

### DIFF
--- a/src/image.jl
+++ b/src/image.jl
@@ -1,3 +1,5 @@
+const g_ImageTexture = Dict{Int,GLuint}()
+
 function ImGui_ImplOpenGL3_CreateImageTexture(image_width, image_height; format=GL_RGBA, type=GL_UNSIGNED_BYTE)
     id = GLuint(0)
     @c glGenTextures(1, &id)


### PR DESCRIPTION
Same as done in https://github.com/JuliaImGui/ImGuiOpenGL2Backend.jl/commit/4badf362b12cfd91ec3fc5d757225ab6e6c398a1