### PR TITLE
Bump version to 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImGuiOpenGLBackend"
 uuid = "9d0819b4-44e7-43a2-ad03-8fb999128168"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "0.1.2"
+version = "0.2"
 
 [deps]
 LibCImGui = "9be01004-c4f5-478b-abeb-cb32b114cf5e"
@@ -9,7 +9,7 @@ ModernGL = "66fc600b-dfda-50eb-8b99-91cfa97b1301"
 
 [compat]
 julia = "1.6"
-LibCImGui = "~1.82"
+LibCImGui = "~1.89"
 ModernGL = "1.1"
 
 [extras]


### PR DESCRIPTION
And bump compat bounds for LibCImGui.jl so it can be used with the 1.89.* releases.